### PR TITLE
feat: add config option to disable the REST endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The configuration object accepts the following parameters:
 - `acls` (array) (optional) allows you to specify LoopBack ACL definitions that will be applied to the Ping model. (Default: no ACL)
 - `modelName` (string) (optional) allows to specify the name of the API endpoint that's used. (Default: 'Ping'),
 - `parts` (object) (optional) allows you to filter out parts of the output by setting the value to false. (Default: show all parts)
+- `rest` (boolean) (optional) set the value to false to disable the REST endpoint. (Default: enable REST endpoint)
 
 ```json
 {
@@ -39,7 +40,8 @@ The configuration object accepts the following parameters:
       "principalType": "ROLE",
       "principalId": "$unauthenticated",
       "permission": "ALLOW"
-    }]
+    }],
+    "rest": true
   }
 }
 ```

--- a/lib/setup-model.js
+++ b/lib/setup-model.js
@@ -21,6 +21,15 @@ function getModelSettings(def) {
 module.exports = function setupModelFn(app, options) {
   debug('setupModelFn')
 
+  if (typeof options.rest === 'boolean' && options.rest === false) {
+    debug('Disable REST')
+    debug(options.rest)
+    delete modelDefinition.methods.ping
+  }
+  else {
+    debug('REST enabled (default)')
+  }
+
   if (typeof options.acls === 'object') {
     debug('Enable ACL')
     debug(options.acls)


### PR DESCRIPTION
It found it useful to disable the REST endpoint if the Ping model is only used internally:

```javascript
System.ping = () => System.app.models.Ping.ping()
```

This PR adds the config option to do so.